### PR TITLE
fix: Daylight saving time off by one hour timestamp.

### DIFF
--- a/src/logger/format/json.format.ts
+++ b/src/logger/format/json.format.ts
@@ -1,6 +1,7 @@
 import { Level } from '../level'
 import { stringify } from '../../utilities/stringify'
 import { applyDateFormat } from './utilities'
+import { normalizeDate } from '../../utilities'
 
 export type Options = {
   timestamp?: boolean
@@ -16,11 +17,12 @@ export function applyFormat(log: any, _options: Options): string {
     pretty: _options.pretty ?? false,
     tabWidth: _options.tabWidth ?? 2n,
   }
+  const date = normalizeDate(new Date())
   return stringify(
     {
       ...log,
       level: Level[log.level].toLowerCase(),
-      ...(options.timestamp ? { timestamp: applyDateFormat(new Date()) } : null),
+      ...(options.timestamp ? { timestamp: applyDateFormat(date) } : null),
     },
     {
       depth: options.depth,

--- a/src/logger/format/plaintext.format.ts
+++ b/src/logger/format/plaintext.format.ts
@@ -2,6 +2,7 @@ import { stringify } from '../../utilities/stringify'
 import { Level } from '../level'
 import { applyDateFormat } from './utilities'
 import { colorFromLevel, underscore } from './colors'
+import { normalizeDate } from '../../utilities'
 
 export type Options = {
   timestamp?: boolean
@@ -20,10 +21,12 @@ export function applyFormat(log: any, _options: Options): string {
     tabWidth: _options.tabWidth ?? 2n,
     color: _options.color ?? false,
   }
+  const date = normalizeDate(new Date())
+
   const colorifySeverity = (text: string) => colorFromLevel(text, options.color ? log.level : undefined)
   const severity = `[${colorifySeverity(Level[log.level].toLowerCase())}]`
   const colorifyTimestamp = (text: string) => options.color ? underscore(text) : text
-  const timestamp = options.timestamp ? `[${colorifyTimestamp(applyDateFormat(new Date()))}]` : ''
+  const timestamp = options.timestamp ? `[${colorifyTimestamp(applyDateFormat(date))}]` : ''
   const tag = log.tag ? `<${log.tag}>` : ''
   const message = stringifyAny(log.message, options)
   const data = log.data ? `\n${stringifyAny(log.data, options)}` : ''

--- a/src/logger/vault/file.vault.ts
+++ b/src/logger/vault/file.vault.ts
@@ -4,6 +4,7 @@ import { Level, isValidLevel } from '../level'
 import { Log } from '../log'
 import { join } from 'path'
 import * as fs from 'fs'
+import { normalizeDate } from '../../utilities'
 
 export type Options = {
   useRotation: boolean
@@ -51,7 +52,7 @@ export class FileVault implements IVault {
   }
 
   private getDateString(): string {
-    const date = new Date()
+    const date = normalizeDate(new Date())
     const dateOfMonth = `0${date.getDate()}`.slice(-2)
     const month = `0${date.getMonth() + 1}`.slice(-2)
     const year = date.getFullYear().toString()

--- a/src/utilities/date.ts
+++ b/src/utilities/date.ts
@@ -1,0 +1,3 @@
+export function normalizeDate(date: Date): Date {
+  return new Date(date.getTime() - date.getTimezoneOffset() * 60 * 1000)
+}

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -1,1 +1,2 @@
 export * from './stringify'
+export * from './date'


### PR DESCRIPTION
The timestamps for logs were off by one hour in winter months due to JS applying daylight saving time (DST).

DST is removed from all date usage across the project.