### PR TITLE
fix: this context is hard bound for public methods.

### DIFF
--- a/__tests__/unit/this-context-change.test.ts
+++ b/__tests__/unit/this-context-change.test.ts
@@ -1,0 +1,72 @@
+import { createDefaultLogger } from '../../src'
+
+describe('Test changes in this context', () => {
+  const ENV = process.env
+
+  beforeEach(() => {
+    jest.resetModules()
+    process.env = { ...ENV }
+
+    process.stdout.write = jest.fn()
+  })
+
+  afterAll(() => {
+    process.env = ENV
+  })
+
+  test('Passing logger.info to a method', () => {
+    function giveMeALogMethod(logMethod: (log: string) => void): void {
+      logMethod('The Message')
+    }
+
+    const logger = createDefaultLogger()
+
+    giveMeALogMethod(logger.info)
+    expect(process.stdout.write).toHaveBeenCalledTimes(1)
+  })
+
+  test('Passing logger.error to a method', () => {
+    function giveMeALogMethod(logMethod: (log: string) => void): void {
+      logMethod('The Message')
+    }
+
+    const logger = createDefaultLogger()
+
+    giveMeALogMethod(logger.error)
+    expect(process.stdout.write).toHaveBeenCalledTimes(1)
+  })
+
+  test('Passing logger.data.info to a method', () => {
+    function giveMeALogMethod(logMethod: (log: string) => void): void {
+      logMethod('The Message')
+    }
+
+    const logger = createDefaultLogger()
+
+    giveMeALogMethod(logger.data({ data: 'info' }).info)
+    expect(process.stdout.write).toHaveBeenCalledTimes(1)
+  })
+
+  test('Passing logger.tag.info to a method', () => {
+    function giveMeALogMethod(logMethod: (log: string) => void): void {
+      logMethod('The Message')
+    }
+
+    const logger = createDefaultLogger()
+
+    giveMeALogMethod(logger.tag('someLoggerTag').info)
+    expect(process.stdout.write).toHaveBeenCalledTimes(1)
+  })
+
+  test('Passing logger.meta.info to a method', () => {
+    function giveMeALogMethod(logMethod: (log: string) => void): void {
+      logMethod('The Message')
+    }
+
+    const logger = createDefaultLogger()
+
+    giveMeALogMethod(logger.meta({ test: '' }).info)
+    expect(process.stdout.write).toHaveBeenCalledTimes(1)
+  })
+})
+

--- a/src/logger/log-context.class.ts
+++ b/src/logger/log-context.class.ts
@@ -10,41 +10,41 @@ export class LogContext implements ILogger {
     this._meta = meta ?? {}
   }
   // Level
-  setLevel(level: Level): void {
+  setLevel = (level: Level): void => {
     this.logger.setLevel(level)
   }
 
   // Attributes
-  tag(tag: string): LogContext {
+  tag = (tag: string): LogContext => {
     return this.meta({ tag })
   }
 
-  data(data: string): LogContext {
+  data = (data: string): LogContext => {
     return this.meta({ data })
   }
 
-  meta(meta: object): LogContext {
+  meta = (meta: object): LogContext => {
     return new LogContext(this.logger, { ...this._meta, ...meta })
   }
 
   // Severity logging
-  error(message: any, meta: object = {}): void {
+  error = (message: any, meta: object = {}): void => {
     return this.logger.error(message, { ...this._meta, ...meta })
   }
 
-  warn(message: any, meta: object = {}): void {
+  warn = (message: any, meta: object = {}): void => {
     return this.logger.warn(message, { ...this._meta, ...meta })
   }
 
-  info(message: any, meta: object = {}): void {
+  info = (message: any, meta: object = {}): void => {
     this.logger.info(message, { ...this._meta, ...meta })
   }
 
-  debug(message: any, meta: object = {}): void {
+  debug = (message: any, meta: object = {}): void => {
     return this.logger.debug(message, { ...this._meta, ...meta })
   }
 
-  trace(message: any, meta: object = {}): void {
+  trace = (message: any, meta: object = {}): void => {
     return this.logger.trace(message, { ...this._meta, ...meta })
   }
 }

--- a/src/logger/logger.class.ts
+++ b/src/logger/logger.class.ts
@@ -30,45 +30,45 @@ export class Logger implements ILogger {
   }
 
   // Level
-  setLevel(level: Level): void {
+  setLevel = (level: Level): void => {
     this.vaults.forEach((vault) => vault.setLevel(level))
   }
 
   // Attributes
-  tag(tag: string): ILogger {
+  tag = (tag: string): ILogger => {
     const context = new LogContext(this)
     return context.tag(tag)
   }
 
-  data(data: any): ILogger {
+  data = (data: any): ILogger => {
     const context = new LogContext(this)
     return context.data(data)
   }
 
-  meta(meta: object): ILogger {
+  meta = (meta: object): ILogger => {
     const context = new LogContext(this)
     return context.meta(meta)
   }
 
   // Severity logging
 
-  error(message: any, meta: object = {}): void {
+  error = (message: any, meta: object = {}): void => {
     this.log(message, Level.error, meta)
   }
 
-  warn(message: any, meta: object = {}): void {
+  warn = (message: any, meta: object = {}): void => {
     this.log(message, Level.warn, meta)
   }
 
-  info(message: any, meta: object = {}): void {
+  info = (message: any, meta: object = {}): void => {
     this.log(message, Level.info, meta)
   }
 
-  debug(message: any, meta: object = {}): void {
+  debug = (message: any, meta: object = {}): void => {
     this.log(message, Level.debug, meta)
   }
 
-  trace(message: any, meta: object = {}): void {
+  trace = (message: any, meta: object = {}): void => {
     this.log(message, Level.trace, meta)
   }
 


### PR DESCRIPTION
Changing the class methods to arrow-function definitions, the `this` context is now hard bound, such that logger methods can be used as first class functions.