### PR TITLE
fix: Use JSON encoder for Error data in plain text formats.

### DIFF
--- a/src/formats/plain-text.format.ts
+++ b/src/formats/plain-text.format.ts
@@ -52,7 +52,7 @@ export class PlainTextFormat extends Format {
       return value
     }
 
-    if (this.typeSpecifier.isObject(value) || this.typeSpecifier.isArray(value)) {
+    if (this.typeSpecifier.isObject(value) || this.typeSpecifier.isArray(value) || this.typeSpecifier.isError(value)) {
       return this.jsonEncoder.encode(value)
     }
 


### PR DESCRIPTION
**Current behaviour**
Only displays Error.message when using the plain text formats.

**New behaviour**
Use the JSON encoder to format Error data in plain text formats, hereby displaying the stacktrace.