### PR TITLE
Web console vault logs data as interactive object instead of as a string

### DIFF
--- a/src/platforms/web/vaults/console.vault.ts
+++ b/src/platforms/web/vaults/console.vault.ts
@@ -23,7 +23,7 @@ export class ConsoleVault extends Vault {
     return text.replace(/\n?$/, '\n')
   }
 
-  private getWrite(level: Level): (message: unknown, data?: unknown) => void {
+  private getWrite(level: Level): (message: string, data?: unknown) => void {
     switch (level) {
       case Level.ERROR:
         return console.error

--- a/src/platforms/web/vaults/console.vault.ts
+++ b/src/platforms/web/vaults/console.vault.ts
@@ -8,21 +8,22 @@ export class ConsoleVault extends Vault {
     if (!this.shouldStore(log)) {
       return
     }
-    const formattedLog = this.format.apply(log)
-    this.printLog(formattedLog, log.level)
+    const { data, ...logWithoutData }: Log = log
+    const formattedLog = this.format.apply(logWithoutData)
+    this.printLog(formattedLog, log.level, data)
   }
 
-  private printLog(message: string, level: Level): void {
+  private printLog(message: string, level: Level, data?: unknown): void {
     const messageWithNewline = this.suffixNewlineIfNotThere(message)
     const write = this.getWrite(level)
-    write(messageWithNewline)
+    write(messageWithNewline, data)
   }
 
   private suffixNewlineIfNotThere(text: string): string {
     return text.replace(/\n?$/, '\n')
   }
 
-  private getWrite(level: Level): (message: string) => void {
+  private getWrite(level: Level): (message: unknown, data?: unknown) => void {
     switch (level) {
       case Level.ERROR:
         return console.error
@@ -34,5 +35,4 @@ export class ConsoleVault extends Vault {
         return console.log
     }
   }
-
 }


### PR DESCRIPTION
This PR introduces that when logging data with `logger.data(data)`, the data object is logged as an interactive object instead of as a string.